### PR TITLE
:bug: fix storybook cannot read stylesheets

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { DocsContainer } from '@storybook/addon-docs';
-import '../stylesheets/freee.scss';
-import '../stylesheets/vibes_2021.scss';
+import '../vibes_2021.min.css';
 import { VibesProvider, useLang } from '../src/utilities/VibesProvider';
 import ReactDOM from 'react-dom';
 


### PR DESCRIPTION
## :memo: 概要

vibes.freee.co.jp のスタイルシートがあたってないので、ひとまずの修正

## :stuck_out_tongue: やってないこと

現在の状態ではリリース済みバージョンのCSSしか当たらない（vibes_2021.min.cssが生成されていないといけないので）

## :heavy_check_mark: 動作確認
<!-- 実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認しよう -->
- [ ] Storybook で 〇〇 が XX できるのを確認

