### PR TITLE
プレビューのgit branchの修正

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -42,7 +42,7 @@ export const parameters = {
   },
   github: {
     repository: 'freee/vibes',
-    branch: 'master',
+    branch: 'main',
   },
 };
 


### PR DESCRIPTION
<!--

**注意**
これは public repositoryです。
ここに書いた情報は、全世界に公開されます。
社内の機密情報、特にリリース前のプロダクトや機能に関する情報を記載しないでください！
 -->

## :memo: 概要
<!-- 変更内容を明記しよう -->
プレビューでgithubに遷移しようとIconをクリックしたら、遷移先ブランチがmasterになっており存在しておりませんでした。
デフォルトブランチがmainだったので、修正漏れかなと思い一応PR出しました。

## :stuck_out_tongue: やってないこと
<!-- この PR ではやってないことなどを明記しよう -->
コンポーネント自体の修正

## :heavy_check_mark: 動作確認
<!-- 実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認しよう -->
- [x] Storybook で コンポーネントが プレビュー できるのを確認

