### PR TITLE
[Storybook] `NumericTable.stories.tsx`のタイポ？を修正

### DIFF
--- a/src/lv2/numericTable/NumericTable.stories.tsx
+++ b/src/lv2/numericTable/NumericTable.stories.tsx
@@ -82,7 +82,7 @@ const sampleRows: Array<NumericTableRow> = [
   },
   {
     cells: [
-      { value: 'ステータスつけれれるよ' },
+      { value: 'ステータスつけられるよ' },
       { value: 'alert', status: 'alert' },
       { value: 'notice', status: 'notice' },
       { value: 'success', status: 'success' },


### PR DESCRIPTION
<!--

**注意**
これは public repositoryです。
ここに書いた情報は、全世界に公開されます。
社内の機密情報、特にリリース前のプロダクトや機能に関する情報を記載しないでください！
 -->

## :memo: 概要
<!-- 変更内容を明記しよう -->

- `NumericTable.stories.tsx`のタイポと思われるテキストを修正（勘違いだったらすみません🙇）

Before | After
-- | --
つけれれるよ | つけられるよ

## :stuck_out_tongue: やってないこと
<!-- この PR ではやってないことなどを明記しよう -->

- コンポーネントの修正
- Storybookも、テキスト以外修正していません

## :heavy_check_mark: 動作確認
<!-- 実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認しよう -->
- [x] Storybook で修正後の文章が表示できるのを確認

![typo-after](https://github.com/freee/vibes/assets/22608727/2999dc15-cef5-44c2-80a7-4625cafc1dc3)
