### PR TITLE
Invokes `onChange()` handler of `DigitsInput` component with `null` when input value is `NaN`

### DIFF
--- a/src/lv2/formFields/DigitsInput.tsx
+++ b/src/lv2/formFields/DigitsInput.tsx
@@ -122,12 +122,14 @@ const useHandlers = ({
       setShowingValue(origValue);
 
       if (onChange) {
-        const numValue =
-          nullable && !origValue
-            ? null
-            : sliceDecimal(Digits.numberize(Ascii.zenkakuToHankaku(origValue)));
+        const numValue = Digits.numberize(Ascii.zenkakuToHankaku(origValue));
 
-        onChange(numValue);
+        // Invokes `onChange()` handler with `null` if the parsed input value is not a finite number.
+        if (!Number.isFinite(numValue)) {
+          return onChange(null);
+        }
+
+        onChange(nullable && !origValue ? null : sliceDecimal(numValue));
       }
     },
     [nullable, onChange, setShowingValue, sliceDecimal]

--- a/src/lv2/formFields/DigitsInput.tsx
+++ b/src/lv2/formFields/DigitsInput.tsx
@@ -124,9 +124,9 @@ const useHandlers = ({
       if (onChange) {
         const numValue = Digits.numberize(Ascii.zenkakuToHankaku(origValue));
 
-        // Invokes `onChange()` handler with `null` if the parsed input value is not a finite number.
+        // Invokes `onChange()` handler with `null` or `0` if the parsed input value is not a finite number.
         if (!Number.isFinite(numValue)) {
-          return onChange(null);
+          return onChange(nullable ? null : 0);
         }
 
         onChange(nullable && !origValue ? null : sliceDecimal(numValue));


### PR DESCRIPTION
<!--

**注意**
これは public repositoryです。
ここに書いた情報は、全世界に公開されます。
社内の機密情報、特にリリース前のプロダクトや機能に関する情報を記載しないでください！
 -->

## :memo: 概要
<!-- 変更内容を明記しよう -->
`DigitsInput` は内部で数字への parse に失敗したときに `NaN` とともに `onChange()` handler が呼び出される.

![image](https://github.com/freee/vibes/assets/10277857/570971bd-b798-4466-b896-5ae5f2a33d63)

そのため利用側で `NaN` を考慮したロジックを実装する必要が出てくる.

本来 `DigitsInput` では `NaN` を取り扱うことは想定していないはずなので, `Number.isFinite()` を使って parse された値が有限数であるか check を行い, 有限数であれば parse された値, そうではない場合は `null` とともに `onChange()` を呼び出すように修正した.

![image](https://github.com/freee/vibes/assets/10277857/f351983b-c732-4e97-bcde-789c7b525f61)

## :stuck_out_tongue: やってないこと
<!-- この PR ではやってないことなどを明記しよう -->

## :heavy_check_mark: 動作確認
<!-- 実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認しよう -->
- [ ] Storybook で 〇〇 が XX できるのを確認

